### PR TITLE
feat(app-img): add lazy load img component

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -167,6 +167,43 @@ declare global {
 declare global {
 
   namespace StencilComponents {
+    interface AppImg {
+      'alt': string;
+      'fit': boolean;
+      'src': string;
+    }
+  }
+
+  interface HTMLAppImgElement extends StencilComponents.AppImg, HTMLStencilElement {}
+
+  var HTMLAppImgElement: {
+    prototype: HTMLAppImgElement;
+    new (): HTMLAppImgElement;
+  };
+  interface HTMLElementTagNameMap {
+    'app-img': HTMLAppImgElement;
+  }
+  interface ElementTagNameMap {
+    'app-img': HTMLAppImgElement;
+  }
+  namespace JSX {
+    interface IntrinsicElements {
+      'app-img': JSXElements.AppImgAttributes;
+    }
+  }
+  namespace JSXElements {
+    export interface AppImgAttributes extends HTMLAttributes {
+      'alt'?: string;
+      'fit'?: boolean;
+      'src'?: string;
+    }
+  }
+}
+
+
+declare global {
+
+  namespace StencilComponents {
     interface AppInput {
       'label': string;
       'name': string;

--- a/src/components/app-footer/app-footer.tsx
+++ b/src/components/app-footer/app-footer.tsx
@@ -26,21 +26,21 @@ export class AppFooter {
             <div class="content col-sm-12 col-md-4">
               <h2>Our Partners</h2>
               <a href="https://ionicframework.com/" target="_blank">
-                <img
+                <app-img
                   class="img-fluid"
                   src="assets/logo-ionic.png"
                   alt="Ionic"
                 />
               </a>
               <a href="http://www.215marketing.com/" target="_blank">
-                <img
+                <app-img
                   class="img-fluid"
                   src="assets/logo-215marketing.png"
                   alt="215 Marketing"
                 />
               </a>
               <a href="https://www.goemerchant.com/" target="_blank">
-                <img
+                <app-img
                   class="img-fluid"
                   src="assets/logo-goemerchant.png"
                   alt="goEmerchant Payment Processing"

--- a/src/components/app-img/app-img.scss
+++ b/src/components/app-img/app-img.scss
@@ -1,0 +1,16 @@
+:host {
+  display: block;
+}
+
+img {
+  max-width: 100%;
+}
+
+img.fit {
+  max-width: none;
+
+  width: 100%;
+  height: 100%;
+  object-fit: inherit;
+  object-position: inherit;
+}

--- a/src/components/app-img/app-img.tsx
+++ b/src/components/app-img/app-img.tsx
@@ -1,0 +1,67 @@
+import { Component, Element, Prop, State, Watch } from '@stencil/core';
+
+@Component({
+  tag: 'app-img',
+  styleUrl: 'app-img.scss',
+  shadow: true,
+})
+export class Img {
+  private io: IntersectionObserver | null = null;
+
+  @Element() el: HTMLElement;
+
+  @State() loadSrc: string;
+
+  @Prop() fit = false;
+  @Prop() alt: string;
+  @Prop() src: string;
+  @Watch('src')
+  srcChanged() {
+    this.addIntersectionObserver();
+  }
+
+  componentDidLoad() {
+    this.addIntersectionObserver();
+  }
+
+  private addIntersectionObserver() {
+    if (!this.src) {
+      return;
+    }
+    if ('IntersectionObserver' in window) {
+      this.removeIntersectionObserver();
+      this.io = new IntersectionObserver(data => {
+        // because there will only ever be one instance
+        // of the element we are observing
+        // we can just use data[0]
+        if (data[0].isIntersecting) {
+          this.loadSrc = this.src;
+          this.removeIntersectionObserver();
+        }
+      });
+
+      this.io.observe(this.el);
+    } else {
+      // fall back to setTimeout for Safari and IE
+      setTimeout(() => (this.loadSrc = this.src), 300);
+    }
+  }
+
+  private removeIntersectionObserver() {
+    if (this.io) {
+      this.io.disconnect();
+      this.io = null;
+    }
+  }
+
+  render() {
+    return (
+      <img
+        class={{ fit: this.fit }}
+        src={this.loadSrc}
+        alt={this.alt}
+        decoding="async"
+      />
+    );
+  }
+}

--- a/src/components/app-members/app-members.tsx
+++ b/src/components/app-members/app-members.tsx
@@ -13,7 +13,7 @@ export class AppMembers {
         {this.members.map(member => (
           <div class="col-sm-12 col-md-4 mb-4">
             <div class="pt-4" style={{ border: `${member.color} 2px solid` }}>
-              <img
+              <app-img
                 class="card-img-top mt-2 px-4"
                 src={member.image}
                 alt={member.name}

--- a/src/components/app-nav-header/app-nav-header.tsx
+++ b/src/components/app-nav-header/app-nav-header.tsx
@@ -38,7 +38,7 @@ export class AppNavHeader {
         <div class="container">
           <div class="navbar-brand">
             <h1>
-              <img
+              <app-img
                 class="img-fluid"
                 src="assets/logo-openforge.png"
                 alt="OpenForge"

--- a/src/components/content-graphic-lg/content-graphic-lg.tsx
+++ b/src/components/content-graphic-lg/content-graphic-lg.tsx
@@ -28,7 +28,11 @@ export class ContentGraphicLg {
             'text-md-right': !this.reverse,
           }}
         >
-          <img class="img-fluid d-none d-md-inline" src={this.imgUrl} alt="" />
+          <app-img
+            class="img-fluid d-none d-md-inline"
+            src={this.imgUrl}
+            alt=""
+          />
         </div>
         <div
           class={{
@@ -39,7 +43,7 @@ export class ContentGraphicLg {
           }}
         >
           <slot name="header" />
-          <img
+          <app-img
             class="img-fluid d-xs-inline d-md-none"
             src={this.imgUrl}
             alt=""

--- a/src/components/content-graphic/content-graphic.tsx
+++ b/src/components/content-graphic/content-graphic.tsx
@@ -20,7 +20,11 @@ export class ContentGraphic {
         }}
       >
         <div class="col-sm-12 col-md-4">
-          <app-img class="img-fluid" src={this.imgUrl} alt="" />
+          <app-img 
+            class="img-fluid" 
+            src={this.imgUrl} 
+            alt="" 
+          />
         </div>
         <div class="content col-sm-12 col-md-7">
           <slot name="header" />

--- a/src/components/content-graphic/content-graphic.tsx
+++ b/src/components/content-graphic/content-graphic.tsx
@@ -20,7 +20,7 @@ export class ContentGraphic {
         }}
       >
         <div class="col-sm-12 col-md-4">
-          <img class="img-fluid" src={this.imgUrl} alt="" />
+          <app-img class="img-fluid" src={this.imgUrl} alt="" />
         </div>
         <div class="content col-sm-12 col-md-7">
           <slot name="header" />

--- a/src/pages/app-home/app-home.tsx
+++ b/src/pages/app-home/app-home.tsx
@@ -45,7 +45,7 @@ export class AppHome {
             <div class="services-selections">
               <a href="#startup">
                 <figure>
-                  <img
+                  <app-img
                     class="img-fluid"
                     src="assets/graphic-home-startup.png"
                     alt=""
@@ -56,7 +56,7 @@ export class AppHome {
 
               <a href="#enterprise">
                 <figure>
-                  <img
+                  <app-img
                     class="img-fluid"
                     src="assets/graphic-home-enterprise.png"
                     alt=""
@@ -89,7 +89,7 @@ export class AppHome {
             </h2>
 
             <div class="services-content">
-              <img
+              <app-img
                 class="img-fluid"
                 src="assets/graphic-home-startup.png"
                 alt=""
@@ -125,7 +125,7 @@ export class AppHome {
             </h2>
 
             <div class="services-content flex-row-reverse">
-              <img
+              <app-img
                 class="img-fluid"
                 src="assets/graphic-home-enterprise.png"
                 alt=""
@@ -154,7 +154,7 @@ export class AppHome {
           <div class="container process">
             <h2>Our Process</h2>
 
-            <img
+            <app-img
               class="img-fluid"
               src="assets/graphic-home-process.png"
               alt="We start with Discovery, then onto Design and Development Consulting, Development, Launch and User Feedback"

--- a/src/pages/app-opportunities/app-opportunities.tsx
+++ b/src/pages/app-opportunities/app-opportunities.tsx
@@ -152,7 +152,7 @@ export class AppOpportunities {
               <div class="row">
                 <div class="image-column col-sm-12 col-md-4">
                   <h3>Angular</h3>
-                  <img
+                  <app-img
                     class="img-fluid d-none d-md-inline"
                     src="assets/graphic-opportunities-phone1.png"
                     alt=""
@@ -160,7 +160,7 @@ export class AppOpportunities {
                 </div>
                 <div class="image-column col-sm-12 col-md-4">
                   <h3>Redux</h3>
-                  <img
+                  <app-img
                     class="img-fluid d-none d-md-inline"
                     src="assets/graphic-opportunities-phone2.png"
                     alt=""
@@ -168,12 +168,12 @@ export class AppOpportunities {
                 </div>
                 <div class="image-column col-sm-12 col-md-4">
                   <h3>API Integration</h3>
-                  <img
+                  <app-img
                     class="img-fluid d-none d-md-inline"
                     src="assets/graphic-opportunities-phone3.png"
                     alt=""
                   />
-                  <img
+                  <app-img
                     class="img-fluid d-xs-inline d-md-none"
                     src="assets/graphic-opportunities-phone4.png"
                     alt=""


### PR DESCRIPTION
This PR replace all img tags with a new component that will handle the lazy load using Intersection Observer API. 

This means faster load time cause we are no longer downloading all assets just the ones needed on the first paint.