### PR TITLE
feat(): add facebook pixel

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -60,6 +60,26 @@
     });
   </script>
 
+  <!-- Facebook Pixel Code -->
+  <script>
+    !function(f,b,e,v,n,t,s)
+    {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+    if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+    n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];
+    s.parentNode.insertBefore(t,s)}(window,document,'script',
+    'https://connect.facebook.net/en_US/fbevents.js');
+    fbq('init', '1961656674133312'); 
+    fbq('track', 'PageView');
+  </script>
+  <noscript>
+    <img height="1" width="1" 
+    src="https://www.facebook.com/tr?id=1961656674133312&ev=PageView
+    &noscript=1"/>
+  </noscript>
+  <!-- End Facebook Pixel Code -->
+  
 </head>
 <body>
   <app-nav-header />

--- a/src/pages/app-about/app-about.tsx
+++ b/src/pages/app-about/app-about.tsx
@@ -1,6 +1,8 @@
 import { Component } from '@stencil/core';
 import { translate } from '../../services/translation.service';
 
+declare var fbq;
+
 @Component({
   tag: 'app-about',
   styleUrl: 'app-about.scss',
@@ -137,6 +139,10 @@ export class AppAbout {
       github: '',
     },
   ];
+
+  componentDidLoad() {
+    fbq('track', 'ViewContent');
+  }
 
   scrollToForm() {
     const form = document.getElementById('about-section');

--- a/src/pages/app-contact/app-contact.tsx
+++ b/src/pages/app-contact/app-contact.tsx
@@ -1,6 +1,8 @@
 import { Component, State, Listen, Prop } from '@stencil/core';
 import { translate } from '../../services/translation.service';
 
+declare var fbq;
+
 @Component({
   tag: 'app-contact',
   styleUrl: 'app-contact.scss',
@@ -82,6 +84,8 @@ export class AppContact {
   }
 
   componentDidLoad() {
+    fbq('track', 'ViewContent');
+    fbq('track', 'Lead');
     this.resetFormValues();
   }
 
@@ -170,6 +174,8 @@ export class AppContact {
           body: JSON.stringify(this.formValues),
         }
       );
+
+      fbq('track', 'CompleteRegistration');
 
       event.target.reset();
       this.resetFormValues();

--- a/src/pages/app-detailed-service/app-detailed-service.tsx
+++ b/src/pages/app-detailed-service/app-detailed-service.tsx
@@ -1,6 +1,8 @@
 import { Component, Prop, State, Listen } from '@stencil/core';
 import { MatchResults } from '@stencil/router';
 
+declare var fbq;
+
 @Component({
   tag: 'app-detailed-service',
   styleUrl: 'app-detailed-service.scss',
@@ -77,6 +79,7 @@ export class AppDetailedService {
   }
 
   componentDidLoad() {
+    fbq('track', 'ViewContent');
     this.resetFormValues();
   }
 

--- a/src/pages/app-home/app-home.tsx
+++ b/src/pages/app-home/app-home.tsx
@@ -1,5 +1,7 @@
 import { Component } from '@stencil/core';
 
+declare var fbq;
+
 @Component({
   tag: 'app-home',
   styleUrl: 'app-home.scss',
@@ -9,6 +11,10 @@ export class AppHome {
   isMobile = navigator.userAgent.match(
     /(iPad)|(iPhone)|(iPod)|(android)|(webOS)/i
   );
+
+  componentDidLoad() {
+    fbq('track', 'ViewContent');
+  }
 
   scrollToForm() {
     const form = document.getElementById('services');

--- a/src/pages/app-opportunities/app-opportunities.tsx
+++ b/src/pages/app-opportunities/app-opportunities.tsx
@@ -1,6 +1,8 @@
 import { Component, State, Listen, Prop } from '@stencil/core';
 import { translate } from '../../services/translation.service';
 
+declare var fbq;
+
 @Component({
   tag: 'app-opportunities',
   styleUrl: 'app-opportunities.scss',
@@ -56,6 +58,8 @@ export class AppOpportunities {
   };
 
   componentDidLoad() {
+    fbq('track', 'ViewContent');
+    fbq('track', 'Lead');
     this.resetFormValues();
   }
 
@@ -200,6 +204,8 @@ export class AppOpportunities {
           body: this.formData,
         }
       );
+
+      fbq('track', 'CompleteRegistration');
 
       e.target.reset();
       this.resetFormValues();


### PR DESCRIPTION
This PR adds facebook pixel to the website. This events were added:

ViewContent - On load for every page
Lead - On load for Contact and Opportunities page
CompleteRegistration - On Contact and Opportunities page after the user sends the form.

If we want add custom events, we need to create them on the facebook panel, by default, there are only 9 to use and i though this ones are the most appropriate for us. 