### PR TITLE
fix(opportunities): update upload file logic for Safari, IE, Edge

### DIFF
--- a/src/pages/app-opportunities/app-opportunities.tsx
+++ b/src/pages/app-opportunities/app-opportunities.tsx
@@ -162,7 +162,8 @@ export class AppOpportunities {
     const files = e.target.files;
     const file = files[0];
 
-    this.formData.delete('files'); // Just in case user changed the file
+    this.formData = new FormData();
+    this.formData.append('files', files[0]);
 
     this.formValues.formErrors.fileValid = e.target.checkValidity();
     if (file && file.size > this.maxFileSize) {
@@ -175,7 +176,6 @@ export class AppOpportunities {
 
     this.fileSizeErrorShown = false;
     this.fileError = '';
-    this.formData.append('files', files[0]);
     this.validateField(null);
   }
 
@@ -206,7 +206,6 @@ export class AppOpportunities {
 
       this.submitButtonDisabled = false;
       this.formSubmitting = false;
-      this.submitButtonDisabled = false;
       this.formSubmitted = true;
       this.fileSizeErrorShown = false;
 
@@ -417,7 +416,7 @@ export class AppOpportunities {
                       class="input-file"
                       type="file"
                       name="file"
-                      onInput={this.handleFile.bind(this)}
+                      onChange={this.handleFile.bind(this)}
                       // onBlur={this.validateField.bind(this)}
                       required={!this.fileSizeErrorShown}
                     />
@@ -521,7 +520,7 @@ export class AppOpportunities {
                       name="message"
                       maxLength={150}
                       required={true}
-                      onInput={this.validateField.bind(this)}
+                      onChange={this.validateField.bind(this)}
                     />
                   </div>
                   <p class="error">


### PR DESCRIPTION
The method [delete](https://developer.mozilla.org/en-US/docs/Web/API/FormData/delete) is not supported in Safari, IE, and Edge. It silently creates an error which causes the form not to be valid, so the user cannot move forward with submitting their information.

The delete was originally intended to update the file in the case that the user wants to upload a different file.  I've researched a few methods, but it is recommended to create a new formData to append the new file to as most manipulation methods are *not* supported on at least 2 of those browsers.

In addition, I'm not sure why there have been duplicate declarations of `this.submitButtonDisabled = false;` so I removed the 2nd instance.