### PR TITLE
fix: add clickable route from logo

### DIFF
--- a/src/components/app-nav-header/app-nav-header.tsx
+++ b/src/components/app-nav-header/app-nav-header.tsx
@@ -35,13 +35,20 @@ export class AppNavHeader {
       <nav class="navbar navbar-expand-xl navbar-dark align-items-lg-end fixed-top">
         <div class="container">
           <div class="navbar-brand">
-            <h1>
-              <app-img
-                class="img-fluid"
-                src="/assets/logo-openforge.png"
-                alt={translate('nav.header.img.alt')}
-              />
-            </h1>
+            <stencil-route-link
+              url="/"
+              exact={true}
+              anchorClass="nav-link"
+              activeClass="active"
+            >
+              <h1>
+                <app-img
+                  class="img-fluid"
+                  src="/assets/logo-openforge.png"
+                  alt={translate('nav.header.img.alt')}
+                />
+              </h1>
+            </stencil-route-link>
           </div>
           <button
             class="navbar-toggler"


### PR DESCRIPTION
Add a stencil router link to the openforge.io logo in order to navigate back to the home page.

Teamwork task reference:
https://openforge.teamwork.com/#tasks/12013053