### PR TITLE
fix: update collapse nav menu to align right

### DIFF
--- a/src/components/app-nav-header/app-nav-header.scss
+++ b/src/components/app-nav-header/app-nav-header.scss
@@ -1,4 +1,6 @@
 nav.navbar .navbar-nav .nav-item {
+  text-align: right;
+
   &.dropdown {
     cursor: pointer;
 
@@ -12,6 +14,7 @@ nav.navbar .navbar-nav .nav-item {
 
     .dropdown-item {
       color: rgba(244, 245, 249, 0.75);
+      text-align: right;
 
       &:hover {
         background: rgba(23, 23, 25, 0.75);


### PR DESCRIPTION
Aligned the menu to display to the right, instead of on the opposite side of the screen.

I noticed another issue with the dropdown that the first 'click' would automatically close the dropdown, until the second click. I found [an issue within bootstrap scripts that cause this issue] (https://stackoverflow.com/questions/24218663/avoid-having-to-double-click-to-toggle-bootstrap-dropdown).

I locally removed my bootstrap.min.js file and it resolved it. I'm not sure of what other issues this would cause within the site as a result so I am going to add a separate issue for this to review separately. For now, please only review the alignment.