### PR TITLE
fix: fix bug where carousel sometimes would not start automatically

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -36,16 +36,11 @@ declare global {
     }
 
     interface AppCta {
-      'hideButton': boolean;
-      'linkUrl': string;
+
     }
 
     interface AppFooter {
 
-    }
-
-    interface AppHeroHome {
-      'textNoWrap': boolean;
     }
 
     interface AppImg {
@@ -187,14 +182,6 @@ declare global {
     var HTMLAppFooterElement: {
       prototype: HTMLAppFooterElement;
       new (): HTMLAppFooterElement;
-    };
-    
-
-    interface HTMLAppHeroHomeElement extends StencilComponents.AppHeroHome, HTMLStencilElement {}
-
-    var HTMLAppHeroHomeElement: {
-      prototype: HTMLAppHeroHomeElement;
-      new (): HTMLAppHeroHomeElement;
     };
     
 
@@ -380,7 +367,6 @@ declare global {
     'app-carousel-indicators': JSXElements.AppCarouselIndicatorsAttributes;
     'app-cta': JSXElements.AppCtaAttributes;
     'app-footer': JSXElements.AppFooterAttributes;
-    'app-hero-home': JSXElements.AppHeroHomeAttributes;
     'app-img': JSXElements.AppImgAttributes;
     'app-input': JSXElements.AppInputAttributes;
     'app-members': JSXElements.AppMembersAttributes;
@@ -413,16 +399,11 @@ declare global {
     }
 
     export interface AppCtaAttributes extends HTMLAttributes {
-      'hideButton'?: boolean;
-      'linkUrl'?: string;
+
     }
 
     export interface AppFooterAttributes extends HTMLAttributes {
 
-    }
-
-    export interface AppHeroHomeAttributes extends HTMLAttributes {
-      'textNoWrap'?: boolean;
     }
 
     export interface AppImgAttributes extends HTMLAttributes {
@@ -550,7 +531,6 @@ declare global {
     'app-carousel-indicators': HTMLAppCarouselIndicatorsElement
     'app-cta': HTMLAppCtaElement
     'app-footer': HTMLAppFooterElement
-    'app-hero-home': HTMLAppHeroHomeElement
     'app-img': HTMLAppImgElement
     'app-input': HTMLAppInputElement
     'app-members': HTMLAppMembersElement
@@ -579,7 +559,6 @@ declare global {
     'app-carousel-indicators': HTMLAppCarouselIndicatorsElement;
     'app-cta': HTMLAppCtaElement;
     'app-footer': HTMLAppFooterElement;
-    'app-hero-home': HTMLAppHeroHomeElement;
     'app-img': HTMLAppImgElement;
     'app-input': HTMLAppInputElement;
     'app-members': HTMLAppMembersElement;

--- a/src/pages/app-home/app-home.tsx
+++ b/src/pages/app-home/app-home.tsx
@@ -20,7 +20,6 @@ export class AppHome {
   private isServer: boolean;
 
   private sticky;
-  jQuery = $;
 
   componentDidLoad() {
     // isServer is false when running in the browser
@@ -83,7 +82,9 @@ export class AppHome {
       }, 0);
 
       setTimeout(() => {
-        (jQuery('#processCarousel') as any).carousel({}).trigger('slide');
+        (function($) {
+          ($('.carousel') as any).carousel();
+        })(jQuery);
       }, 3000);
 
       $(window).trigger('scroll'); // init the value

--- a/src/pages/app-home/app-home.tsx
+++ b/src/pages/app-home/app-home.tsx
@@ -20,6 +20,7 @@ export class AppHome {
   private isServer: boolean;
 
   private sticky;
+  jQuery = $;
 
   componentDidLoad() {
     // isServer is false when running in the browser
@@ -147,7 +148,7 @@ export class AppHome {
             </h2>
           </div>
 
-          <div id="processCarousel" class="carousel slide" data-ride="carousel">
+          <div id="processCarousel" class="carousel slide">
             <app-carousel-indicators
               class="carousel-main-indicators"
               activeIndex="0"

--- a/src/pages/app-home/app-home.tsx
+++ b/src/pages/app-home/app-home.tsx
@@ -81,11 +81,19 @@ export class AppHome {
         self.sticky.updateSticky();
       }, 0);
 
+      // setTimeout(() => {
+      //   (jQuery('#processCarousel') as any).carousel({}).trigger('slide');
+      // }, 3000);
+
       setTimeout(() => {
-        (function($) {
-          ($('.carousel') as any).carousel();
-        })(jQuery);
+        jQuery('#processCarousel').carousel();
       }, 3000);
+
+      // setTimeout(() => {
+      //   (function ($) {
+      //     ($('.carousel') as any).carousel();
+      //   })(jQuery);
+      // }, 3000);
 
       $(window).trigger('scroll'); // init the value
 

--- a/src/pages/app-home/app-home.tsx
+++ b/src/pages/app-home/app-home.tsx
@@ -21,7 +21,6 @@ export class AppHome {
 
   private sticky;
 
-
   componentDidLoad() {
     // isServer is false when running in the browser
     // and true when being prerendered
@@ -82,7 +81,9 @@ export class AppHome {
         self.sticky.updateSticky();
       }, 0);
 
-      $('[data-slide-to=0]').trigger('click');
+      setTimeout(() => {
+        (jQuery('#processCarousel') as any).carousel({}).trigger('slide');
+      }, 3000);
 
       $(window).trigger('scroll'); // init the value
 
@@ -235,7 +236,7 @@ export class AppHome {
                   <div class="col-lg-6 col-md-6 col-sm-12 carousel-panel align-self-center">
                     <div class="carousel-text">
                       <h2>
-                      < app-translate key="home.process.deployment.title" />
+                        <app-translate key="home.process.deployment.title" />
                       </h2>
                       <app-carousel-indicators
                         class="carousel-mobile-indicators"
@@ -306,12 +307,8 @@ export class AppHome {
               <div class="content-panel loudcloud">
                 <div class="content-panel-inner description">
                   <div class="panel-inner-text">
-                    <h2>
-                      {translate('home.services.mobileTechnology.title')}
-                    </h2>
-                    <p>
-                      {translate('home.services.mobileTechnology.text')}
-                    </p>
+                    <h2>{translate('home.services.mobileTechnology.title')}</h2>
+                    <p>{translate('home.services.mobileTechnology.text')}</p>
                   </div>
                 </div>
                 <div class="content-panel-image">
@@ -348,9 +345,7 @@ export class AppHome {
                     <h2>
                       {translate('home.services.digitalExperience.title')}
                     </h2>
-                    <p>
-                      {translate('home.services.digitalExperience.text')}
-                    </p>
+                    <p>{translate('home.services.digitalExperience.text')}</p>
                   </div>
                 </div>
                 <div class="content-panel-image">
@@ -384,12 +379,8 @@ export class AppHome {
               <div class="content-panel juntoscope">
                 <div class="content-panel-inner description">
                   <div class="panel-inner-text">
-                    <h2>
-                      {translate('home.services.brandingDesign.title')}
-                    </h2>
-                    <p>
-                      {translate('home.services.brandingDesign.text')}
-                    </p>
+                    <h2>{translate('home.services.brandingDesign.title')}</h2>
+                    <p>{translate('home.services.brandingDesign.text')}</p>
                   </div>
                 </div>
                 <div class="content-panel-image">
@@ -427,9 +418,8 @@ export class AppHome {
 
         {/* aside - cta */}
         <app-cta />
-        
-        <app-footer />
 
+        <app-footer />
       </div>
     );
   }

--- a/src/pages/app-home/app-home.tsx
+++ b/src/pages/app-home/app-home.tsx
@@ -66,6 +66,7 @@ export class AppHome {
 
     /* tslint:disable-next-line */
     $(document).ready(function() {
+      jQuery.noConflict();
       /* tslint:disable-next-line */
       const self = this;
       /* tslint:disable-next-line */


### PR DESCRIPTION
As far as I can tell, something about how the Stencil lifecycle works is preventing the carousel from starting sometimes. Interestingly enough, without the timeout, the carousel won't start if you scroll down to it as soon as the page loads. However, if you click _outside_ of the browser window (or in another tab) and do something else for a second, the carousel will (sometimes) start. This makes me think that the component is not properly recognized as completely loaded until that happens, for some reason. (All of the above refers to the page running on my localhost. Things seem slightly different on the live website).

I used a jquery method to start the carousel manually, after a specified timeout of three seconds. On my machine, when the timeout was 2 seconds, the carousel would start about 80% or 90% of the time. When I changed it to 3 seconds, it worked every time, at least on my computer. Other browsers and machines might vary.