### PR TITLE
Fix/dropdown styles

### DIFF
--- a/src/components/app-nav-header/app-nav-header.scss
+++ b/src/components/app-nav-header/app-nav-header.scss
@@ -26,6 +26,9 @@ button.navbar-toggler {
 }
 
 nav.navbar .navbar-nav .nav-item {
+  .active {
+    color: $orange;
+  }
   text-align: left;
 
   @include media-breakpoint-down(md) {

--- a/src/components/app-nav-header/app-nav-header.scss
+++ b/src/components/app-nav-header/app-nav-header.scss
@@ -126,6 +126,9 @@ nav.navbar .navbar-nav .nav-link {
       margin-top: 0.5rem;
       margin-bottom: 1.5rem;
     }
+    &.active {
+      color: $orange;
+    }
   }
 }
 

--- a/src/components/app-nav-header/app-nav-header.tsx
+++ b/src/components/app-nav-header/app-nav-header.tsx
@@ -78,10 +78,19 @@ export class AppNavHeader {
                   </stencil-route-link>
                 </li>
                 <li class="nav-item dropdown" data-target="#navbarSupportedContent">
-                  <a href="" class="nav-link dropdown-toggle" id="navbarDropdown1" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  <stencil-route-link
+                    urlMatch={['/blog', '/forge']}
+                    activeClass="active"
+                    anchorClass="nav-link dropdown-toggle"
+                    id="navbarDropdown0"
+                    role="button"
+                    data-toggle="dropdown"
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                  >
                     {translate('nav.links.resources')}
-                  </a>
-                  <div class="dropdown-menu" aria-labelledby="navbarDropdown1">
+                  </stencil-route-link>
+                  <div class="dropdown-menu" aria-labelledby="navbarDropdown0">
                     <stencil-route-link url="/blog" anchorClass="nav-link dropdown-item" activeClass="active">
                       Blog
                     </stencil-route-link>

--- a/src/pages/open-forge-app/open-forge-app.tsx
+++ b/src/pages/open-forge-app/open-forge-app.tsx
@@ -21,13 +21,6 @@ export class OpenForgeApp {
 
     if (this.mainEl) {
       this.mainEl.addEventListener('click', ev => {
-        const aboutDropDown = document.getElementById('navbarDropdown1');
-        if (this.checkInAbout()) {
-          aboutDropDown.className = 'nav-link dropdown-toggle active';
-        } else {
-          aboutDropDown.className = 'nav-link dropdown-toggle';
-        }
-
         const srcEl = ev.srcElement as HTMLElement;
         if (srcEl.classList.contains('dropdown-toggle')) {
           return;
@@ -42,10 +35,6 @@ export class OpenForgeApp {
         }
       });
     }
-  }
-
-  checkInAbout() {
-    return window.location.pathname === '/about' || window.location.pathname === '/juntoscope' || window.location.pathname === '/toolbox' || window.location.pathname === '/resources/pwa-white-paper';
   }
 
   render() {


### PR DESCRIPTION
Link to Task: https://openforge.teamwork.com/#/tasks/17477929

Change: Jan.8
- fix: remove click listener that was setting active
This was setting active outside of the navbar component, making route changes inside the component a breaking change that was hard to see.

- fix: change anchor to stencil-route-link
This sets the active class based on the stencil router state just like any other route component.

- fix: add less exclusive active class
At some point, the items in the navbar lost their active state, likely due to the nesting of its styles being moved around, so there's a more general style, since setting the active class is likely scoped to the dropdowns there.

Change: Jan.9
- fix: add another active style class because of specificity issue
The styles for the work-with-us button are 4 levels of specificity, which makes styling a generic active style difficult. So I added an active class within that work-with-us definition to set the desired text color when active. Not a bad change considering the difference in appearance between the work-with-us and the other tabs that might diverge in active styling in the future anyway.