### PR TITLE
fix(contact): bold labels

### DIFF
--- a/src/components/app-input/app-input.scss
+++ b/src/components/app-input/app-input.scss
@@ -7,7 +7,6 @@
 
   label {
     color: $green;
-    font-weight: 600;
   }
 
   input {


### PR DESCRIPTION
https://openforge.teamwork.com/#/tasks/17495231

I removed the bold styles when the input is valid, other places I didn't see them in bold. This applies to mobile, tablet, desktop.