### PR TITLE
Fix/font styles mobile

### DIFF
--- a/src/assets/fonts/Roboto.css
+++ b/src/assets/fonts/Roboto.css
@@ -1,6 +1,6 @@
 /* cyrillic-ext */
 @font-face {
-  font-family: 'Roboto';
+  font-family: 'Roboto-Bold';
   font-style: normal;
   font-weight: 700;
   src: local('Roboto Bold'), local('Roboto-Bold'), url(https://fonts.gstatic.com/s/roboto/v18/KFOlCnqEu92Fr1MmWUlfCRc4AMP6lbBP.woff2) format('woff2');
@@ -9,7 +9,7 @@
 }
 /* cyrillic */
 @font-face {
-  font-family: 'Roboto';
+  font-family: 'Roboto-Bold';
   font-style: normal;
   font-weight: 700;
   src: local('Roboto Bold'), local('Roboto-Bold'), url(https://fonts.gstatic.com/s/roboto/v18/KFOlCnqEu92Fr1MmWUlfABc4AMP6lbBP.woff2) format('woff2');
@@ -18,7 +18,7 @@
 }
 /* greek-ext */
 @font-face {
-  font-family: 'Roboto';
+  font-family: 'Roboto-Bold';
   font-style: normal;
   font-weight: 700;
   src: local('Roboto Bold'), local('Roboto-Bold'), url(https://fonts.gstatic.com/s/roboto/v18/KFOlCnqEu92Fr1MmWUlfCBc4AMP6lbBP.woff2) format('woff2');
@@ -27,7 +27,7 @@
 }
 /* greek */
 @font-face {
-  font-family: 'Roboto';
+  font-family: 'Roboto-Bold';
   font-style: normal;
   font-weight: 700;
   src: local('Roboto Bold'), local('Roboto-Bold'), url(https://fonts.gstatic.com/s/roboto/v18/KFOlCnqEu92Fr1MmWUlfBxc4AMP6lbBP.woff2) format('woff2');
@@ -36,7 +36,7 @@
 }
 /* vietnamese */
 @font-face {
-  font-family: 'Roboto';
+  font-family: 'Roboto-Bold';
   font-style: normal;
   font-weight: 700;
   src: local('Roboto Bold'), local('Roboto-Bold'), url(https://fonts.gstatic.com/s/roboto/v18/KFOlCnqEu92Fr1MmWUlfCxc4AMP6lbBP.woff2) format('woff2');
@@ -54,7 +54,7 @@
 }
 /* latin */
 @font-face {
-  font-family: 'Roboto';
+  font-family: 'Roboto-Bold';
   font-style: normal;
   font-weight: 700;
   src: local('Roboto Bold'), local('Roboto-Bold'), url(https://fonts.gstatic.com/s/roboto/v18/KFOlCnqEu92Fr1MmWUlfBBc4AMP6lQ.woff2) format('woff2');

--- a/src/components/app-search-results/app-search-results.scss
+++ b/src/components/app-search-results/app-search-results.scss
@@ -140,7 +140,7 @@
     width: 125px;
     height: 32px;
     color: #ffffff;
-    font-family: Roboto;
+    font-family: 'Roboto-Bold';
     font-size: 11px;
     font-weight: 700;
     letter-spacing: 1.25px;

--- a/src/pages/app-detailed-service/app-detailed-service.scss
+++ b/src/pages/app-detailed-service/app-detailed-service.scss
@@ -171,7 +171,7 @@
       box-shadow: 0 2px 4px 0 rgba(128, 128, 128, 0.5);
       color: $gray-dark;
       cursor: pointer;
-      font-family: Roboto;
+      font-family: 'Roboto-Bold';
       font-size: 11px;
       font-weight: bold;
       font-style: normal;

--- a/src/pages/app-partners/app-partners.scss
+++ b/src/pages/app-partners/app-partners.scss
@@ -226,7 +226,7 @@
       color: #ffffff;
       width: 130px;
       cursor: pointer;
-      font-family: Roboto;
+      font-family: 'Roboto-Bold';
       font-size: 11px;
       font-weight: bold;
       font-style: normal;


### PR DESCRIPTION
https://openforge.teamwork.com/#/tasks/17495271
https://openforge.teamwork.com/#/tasks/17495218
https://openforge.teamwork.com/#/tasks/17495231

This is just the fix to stop Roboto from force rendering Roboto Bold, which can't change font-weight in mobile chrome. 

I'm going to split the PR's that fix the rendering issue from styling components with the Multi font. For that, the reason I can't quickly style the heading tags as they are in the style guide is because the semantic headers probably don't line up with the style guide and likely depend on inherited styles to appear the way they do.