### PR TITLE
fix(): reduce the data request on home blog posts

### DIFF
--- a/src/pages/app-home/app-home.tsx
+++ b/src/pages/app-home/app-home.tsx
@@ -75,8 +75,9 @@ export class AppHome {
 
   async getFeaturedPost() {
     this.featuredIsLoading = true;
-    this.featuredPost = await Fetch.fetchOneBlogPost();
-    this.featuredPost1 = await Fetch.fetchOneBlogPost(1);
+    const homePosts = await Fetch.fetchHomeBlogPosts();
+    this.featuredPost = homePosts.first;
+    this.featuredPost1 = homePosts.second;
     this.featuredIsLoading = false;
   }
 

--- a/src/shared/fetch-handler.ts
+++ b/src/shared/fetch-handler.ts
@@ -19,6 +19,24 @@ export async function fetchOneBlogPost(postNum: number = 0) {
     });
 }
 
+export async function fetchHomeBlogPosts() {
+  return await fetch(`${urlPosts}?${authToken}&page_size=2`)
+    .then(res => res.json())
+    .then(resp => {
+      if (resp.data.length > 1) {
+        return {
+          first: resp.data[0],
+          second: resp.data[1],
+        };
+      }
+      return null;
+    })
+    .catch(resp => {
+      console.log(resp);
+      return null;
+    });
+}
+
 export async function fetchBlogPosts() {
   return await fetch(`${urlPosts}?${authToken}`)
     .then(res => res.json())


### PR DESCRIPTION
https://openforge.teamwork.com/#/tasks/17524798

I saw that we where requesting to butter cms all the blogs that comes in one page (10) twice, and then just getting the number 0 on the first one, and the number 1 on the second. So I just swap to just call once and with the page only for those 2 first items.